### PR TITLE
import libsbol to get access to TopLevel

### DIFF
--- a/pySBOLx/pySBOLx.py
+++ b/pySBOLx/pySBOLx.py
@@ -1,5 +1,6 @@
 import rdflib
 from sbol import *
+from sbol.libsbol import *
 
 SD2_NS = 'http://sd2e.org#'
 


### PR DESCRIPTION
I get an error that is something link 'Cannot find TopLevel'. TopLevel appears is defined under sbol.libsbol, so I just imported that whole namespace.